### PR TITLE
fix: fix reversi codes for passing tests

### DIFF
--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative './position'
-require 'debug'
 
 module ReversiMethods
   WHITE_STONE = 'W'

--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -87,7 +87,7 @@ module ReversiMethods
         return true if put_stone(board, position.to_cell_ref, attack_stone_color, dry_run: true)
       end
     end
-    return false
+    false
   end
 
   def count_stone(board, stone_color)

--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -47,8 +47,8 @@ module ReversiMethods
 
     # コピーした盤面にて石の配置を試みて、成功すれば反映する
     copied_board = Marshal.load(Marshal.dump(board))
-    copied_board[pos.col][pos.row] = stone_color
-
+    copied_board[pos.row][pos.col] = stone_color
+    
     turn_succeed = false
     Position::DIRECTIONS.each do |direction|
       next_pos = pos.next_position(direction)
@@ -56,13 +56,14 @@ module ReversiMethods
     end
 
     copy_board(board, copied_board) if !dry_run && turn_succeed
-
+    
     turn_succeed
   end
 
   def turn(board, target_pos, attack_stone_color, direction)
     return false if target_pos.out_of_board?
     return false if target_pos.stone_color(board) == attack_stone_color
+    return false if target_pos.stone_color(board) == BLANK_CELL
 
     next_pos = target_pos.next_position(direction)
     if (next_pos.stone_color(board) == attack_stone_color) || turn(board, next_pos, attack_stone_color, direction)
@@ -74,7 +75,7 @@ module ReversiMethods
   end
 
   def finished?(board)
-    !placeable?(board, WHITE_STONE) && !placeable?(board, BLACK_STONE)
+    !placeable?(board, WHITE_STONE) && !placeable?(board, BLACK_STONE) || count_stone(board, BLANK_CELL) == 0 || count_stone(board, WHITE_STONE) == 0 || count_stone(board, BLACK_STONE) == 0 
   end
 
   def placeable?(board, attack_stone_color)

--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative './position'
+require 'debug'
 
 module ReversiMethods
   WHITE_STONE = 'W'
@@ -48,7 +49,7 @@ module ReversiMethods
     # コピーした盤面にて石の配置を試みて、成功すれば反映する
     copied_board = Marshal.load(Marshal.dump(board))
     copied_board[pos.row][pos.col] = stone_color
-    
+
     turn_succeed = false
     Position::DIRECTIONS.each do |direction|
       next_pos = pos.next_position(direction)
@@ -75,7 +76,7 @@ module ReversiMethods
   end
 
   def finished?(board)
-    !placeable?(board, WHITE_STONE) && !placeable?(board, BLACK_STONE) || count_stone(board, BLANK_CELL) == 0 || count_stone(board, WHITE_STONE) == 0 || count_stone(board, BLACK_STONE) == 0 
+    !placeable?(board, WHITE_STONE) && !placeable?(board, BLACK_STONE)
   end
 
   def placeable?(board, attack_stone_color)
@@ -87,6 +88,7 @@ module ReversiMethods
         return true if put_stone(board, position.to_cell_ref, attack_stone_color, dry_run: true)
       end
     end
+    return false
   end
 
   def count_stone(board, stone_color)

--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -56,7 +56,7 @@ module ReversiMethods
     end
 
     copy_board(board, copied_board) if !dry_run && turn_succeed
-    
+
     turn_succeed
   end
 


### PR DESCRIPTION
※https://github.com/tasogare0919/bug_reversi/pull/1 の PR が汚かったので作り直しました。

# テストコード実行結果
コード修正後にテストを全てパスしたのを確認した結果を以下に貼ります。

```sh
❯ ruby test/reversi_methods_test.rb        
Run options: --seed 23113

# Running:

.........

Finished in 0.004676s, 1924.7220 runs/s, 3849.4440 assertions/s.

9 runs, 18 assertions, 0 failures, 0 errors, 0 skips
```